### PR TITLE
Support mo(s)/mon(s) for months

### DIFF
--- a/lib/Time/Duration/Parse.pm
+++ b/lib/Time/Duration/Parse.pm
@@ -14,7 +14,7 @@ my %Units = ( map(($_,             1), qw(s second seconds sec secs)),
               map(($_,         60*60), qw(h hr hour hours)),
               map(($_,      60*60*24), qw(d day days)),
               map(($_,    60*60*24*7), qw(w week weeks)),
-              map(($_,   60*60*24*30), qw(M month months)),
+              map(($_,   60*60*24*30), qw(M month months mo mos mon mons)),
               map(($_,  60*60*24*365), qw(y year years)) );
 
 sub parse_duration {


### PR DESCRIPTION
If min(s) and sec(s) are accepted for minutes and seconds respectively, might
just as well support mo(n)(s) for months.