### PR TITLE
switch to plain Exporter

### DIFF
--- a/lib/Time/Duration/Parse.pm
+++ b/lib/Time/Duration/Parse.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 
 use Carp;
-use Exporter::Lite;
+use Exporter 5.57 qw(import);
 our @EXPORT = qw( parse_duration );
 
 # This map is taken from Cache and Cache::Cache


### PR DESCRIPTION
Exporter::Lite provides no extra functionality, and Exporter will almost
always be loaded anyway so it is just extra memory used.

Switch to Exporter 5.57, which allows importing Exporter's import rather
than inheriting from it.